### PR TITLE
Add Dockerfile to enable Docker support (locally)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:latest
+
+RUN pip install --upgrade rpi_ws281x flask
+
+COPY . .
+
+CMD [ "python" ,"pixelserver.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
-FROM python:latest
+FROM python:alpine
 
-RUN pip install --upgrade rpi_ws281x flask
+ENV VIRTUAL_ENV=/opt/venv
+
+RUN python -m venv $VIRTUAL_ENV
+
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN apk add build-base linux-headers --no-cache && \
+    pip install --upgrade --no-cache-dir rpi_ws281x flask RPi.GPIO setuptools
 
 COPY . .
 
-CMD [ "python" ,"pixelserver.py" ]
+CMD [ "python", "pixelserver.py" ]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ Enable using:
 
 For more information see: <http://www.penguintutor.com/raspberrypi/startup>
 
+### Docker install
+
+If you wish to use this project in a container, you can do so by entering the following commands:
+
+    cd ~
+    sudo mkdir pixel-server
+    sudo chown $USER: pixel-server
+    git clone https://github.com/penguintutor/pixel-server.git pixel-server
+    
+Make sure to make changes to your config file, so that the pixel-server knows how to communicate with your neopixel device!
+    
+    docker build . -t pixel-server
+    docker run --restart unless-stopped --privileged -p 80:80 pixel-server
+
+This will make the project run on port 80/HTTP and also start on boot.
+To update the container, enter the following commands:
+
+    docker stop pixel-server
+    docker rm pixel-server
+    cd ~/pixel-server/
+    git pull
+    docker build . -t pixel-server
+    docker run --restart unless-stopped --privileged -p 80:80 pixel-server
+
+
 # Automation
 
 You can automate the light sequences being turned on and off by using crontab. For example:


### PR DESCRIPTION
A bit from this issue: https://github.com/penguintutor/pixel-server/issues/1

This PR focuses on adding a Dockerfile with the needed steps for a user to make a container image, to run the project with docker.

If you like, this image can be hosted on dockerhub and users only need to use the run command to use the project.
But, we do need to instruct the user to wget/download the config file, edit it, and then store it and use the volume parameter so that the container has persistant access to the config file.

If you do want to make a container image on the internet, i can also look into a CI/CD so that each commit/release triggers a new image version and updates the latest tag, so users can automatically update with watchtower!